### PR TITLE
fix: issue when webpack footer not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
 .DS_Store
-dist
+dist.js

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Restores file structure from source map (only Webpack source map files supported
 ```sh
 > npm i -g restore-source-tree
 
-> restore-source-tree --out-dir <OUT_DIR> <FILE>
+> restore-source-tree --out-dir <OUT_DIR> <FILE1> <FILE2> <FILE3>
 ```

--- a/bin/restore-source-tree.js
+++ b/bin/restore-source-tree.js
@@ -1,3 +1,3 @@
 #! /usr/bin/env node
 
-require('../dist/index.js');
+require('../dist.js');

--- a/index.js
+++ b/index.js
@@ -83,14 +83,11 @@ function processFile(filename) {
   console.log(`Processed ${sources.length} files`);
 }
 
-const filename = program.args[0];
-
-fs.access(filename, err => {
-  if (err) {
+program.args.forEach((filename) => {
+  try {
+    fs.accessSync(filename);
+    processFile(filename);
+  } catch (err) {
     console.error(err.message);
-    process.exit(1);
   }
-
-  processFile(filename);
 });
-

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import glob from 'glob';
 import { version } from './package.json';
 
 const WEBPACK_PREFIX = 'webpack:///';
-const WEBPACK_FOOTER = '/** WEBPACK FOOTER **';
+const WEBPACK_FOOTER = ['/** WEBPACK FOOTER', '// WEBPACK FOOTER'];
 
 const program = new Command('restore-source-tree')
   .version(version)
@@ -45,7 +45,10 @@ const getSourceList = smc => {
 }
 
 const trimFooter = (str) => {
-  const index = str.indexOf(WEBPACK_FOOTER);
+  const index = WEBPACK_FOOTER.reduce((result, footer) => {
+    if (result >= 0) return result;
+    return str.indexOf(footer);
+  }, -1);
   if (index < 0) return str;
   return str.substr(0, index).trimRight() + '\n';
 };

--- a/index.js
+++ b/index.js
@@ -3,12 +3,13 @@ import path from 'path';
 import mkdirp from 'mkdirp';
 import { SourceMapConsumer } from 'source-map';
 import { Command } from 'commander';
+import { version } from './package.json';
 
 const WEBPACK_PREFIX = 'webpack:///';
 const WEBPACK_FOOTER = '/** WEBPACK FOOTER **';
 
 const program = new Command('restore-source-tree')
-  .version('0.1.1')
+  .version(version)
   .usage('[options] <file>')
   .description('Restores file structure from source map')
   .option('-o, --out-dir [dir]', 'Output directory (\'output\' by default)', 'output')

--- a/index.js
+++ b/index.js
@@ -43,7 +43,11 @@ const getSourceList = smc => {
   return sources;
 }
 
-const trimFooter = str => str.substr(0, str.indexOf(WEBPACK_FOOTER)).trimRight() + '\n';
+const trimFooter = (str) => {
+  const index = str.indexOf(WEBPACK_FOOTER);
+  if (index < 0) return str;
+  return str.substr(0, index).trimRight() + '\n';
+};
 
 const saveSourceContent = (smc, filePath, src) => {
   const content = trimFooter(smc.sourceContentFor(src));

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import path from 'path';
 import mkdirp from 'mkdirp';
 import { SourceMapConsumer } from 'source-map';
 import { Command } from 'commander';
+import glob from 'glob';
 import { version } from './package.json';
 
 const WEBPACK_PREFIX = 'webpack:///';
@@ -83,7 +84,10 @@ function processFile(filename) {
   console.log(`Processed ${sources.length} files`);
 }
 
-program.args.forEach((filename) => {
+program.args
+.map(pattern => glob.sync(pattern))
+.reduce((prev, curr) => prev.concat(curr), [])
+.forEach((filename) => {
   try {
     fs.accessSync(filename);
     processFile(filename);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import glob from 'glob';
 import { version } from './package.json';
 
 const WEBPACK_PREFIX = 'webpack:///';
-const WEBPACK_FOOTER = ['/** WEBPACK FOOTER', '// WEBPACK FOOTER'];
+const WEBPACK_FOOTER = [/\/*[*\s]+WEBPACK FOOTER/, /\/\/ WEBPACK FOOTER/];
 
 const program = new Command('restore-source-tree')
   .version(version)
@@ -47,7 +47,9 @@ const getSourceList = smc => {
 const trimFooter = (str) => {
   const index = WEBPACK_FOOTER.reduce((result, footer) => {
     if (result >= 0) return result;
-    return str.indexOf(footer);
+    const match = footer.exec(str);
+    if (!match) return -1;
+    return match.index;
   }, -1);
   if (index < 0) return str;
   return str.substr(0, index).trimRight() + '\n';

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "restore-source-tree",
   "version": "0.1.1",
   "description": "Restores file structure from source map",
-  "main": "index.js",
+  "main": "dist.js",
   "bin": {
     "restore-source-tree": "bin/restore-source-tree.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "NODE_ENV=production babel index.js --out-dir dist",
+    "build": "NODE_ENV=production babel index.js --out-file dist.js",
     "prepublish": "npm run build"
   },
   "author": "Alexander <alexkuz@gmail.com> (http://kuzya.org/)",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^2.9.0",
+    "glob": "^7.1.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "source-map": "^0.5.6"


### PR DESCRIPTION
this PR is tend to do following things:

+ fix an issue, where content won't output when webpack footer not found
+ modify the project structure, so that `version` can be read directly from `package.json` (instead of hard-coded) and `index.js` won't be published in npm package (as it's not necessary)
+ add feature to allow input of multiple files
+ add glob support for input